### PR TITLE
fixed two bugs

### DIFF
--- a/R/mk8dx-package.R
+++ b/R/mk8dx-package.R
@@ -10,5 +10,6 @@ ignore_unused_imports <- function() {
 }
 
 utils::globalVariables(c("segment_name_path",
-                         "segment_time_path"))
+                         "segment_time_path",
+                         "segment_id"))
 

--- a/R/mk_segments.R
+++ b/R/mk_segments.R
@@ -12,12 +12,20 @@ mk_segments <- function(lss) {
   segment_names <- xml_find_all(lss, "//Segment/Name")
   best_segment_nodes <- xml_find_all(lss, "//Segment/BestSegmentTime/RealTime")
 
-  tibble(
+  segments <- tibble(
     segment_name = xml_text(segment_names),
     segment_name_path = xml_path(segment_names),
     segment_id = str_extract(segment_name_path, "(?<=Segment.)\\d"),
     best_segment_time = xml_text(best_segment_nodes)
   ) %>%
     select("segment_id", "segment_name", "best_segment_time")
+
+  bad_segment_id <- count(segments, segment_id)
+
+  if (nrow(bad_segment_id) >= 1) {
+    segments %>% mutate(segment_id = row_number())
+  } else {
+    segments
+  }
 
 }

--- a/R/mk_variables.R
+++ b/R/mk_variables.R
@@ -12,11 +12,18 @@ mk_variables <- function(lss) {
 
   variable_nodes <- xml_find_all(lss, "//Variable")
 
-  tibble(
-    category = xml_text(xml_child(lss, "CategoryName")),
-    attempt_count = xml_text(xml_child(lss, "AttemptCount")),
-    name = xml_attr(variable_nodes, "name"),
-    value = xml_text(variable_nodes)
-  ) %>%
-    pivot_wider() %>% janitor::clean_names()
+  if (length(variable_nodes) == 0) {
+    tibble(
+      category = xml_text(xml_child(lss, "CategoryName")),
+      attempt_count = xml_text(xml_child(lss, "AttemptCount"))
+    )
+  } else {
+    tibble(
+      category = xml_text(xml_child(lss, "CategoryName")),
+      attempt_count = xml_text(xml_child(lss, "AttemptCount")),
+      name = xml_attr(variable_nodes, "name"),
+      value = xml_text(variable_nodes)
+    ) %>%
+      pivot_wider() %>% janitor::clean_names()
+  }
 }

--- a/tests/testthat/test-mk_segments.R
+++ b/tests/testthat/test-mk_segments.R
@@ -1,0 +1,3 @@
+test_that("multiplication works", {
+  expect_equal(2 * 2, 4)
+})


### PR DESCRIPTION
- if a file does not have any metadata variables, variables will not be included
- if a files segment ids are messed up (duplicate ids), the row number of the segment will be used instead.